### PR TITLE
Update segment editor URL in configPage.html

### DIFF
--- a/Jellyfin.Plugin.MediaSegmentsApi/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MediaSegmentsApi/Configuration/configPage.html
@@ -11,7 +11,7 @@
                 <form id="MediaSegmentsApiConfigForm">
                     <div class="selectContainer">
                         <label class="selectLabel" for="Options">Please read!</label>
-                        <div class="fieldDescription">This plugin provides an extended HTTP API to manage MediaSegments. See also: <a target="_blank" href="https://github.com/endrl/segment-editor?tab=readme-ov-file#jellyfin-segment-editor">Jellyfin Segment Editor
+                        <div class="fieldDescription">This plugin provides an extended HTTP API to manage MediaSegments. See also: <a target="_blank" href="https://github.com/intro-skipper/segment-editor?tab=readme-ov-file#jellyfin-segment-editor">Jellyfin Segment Editor
 <a></div>
                     </div>
                     <!--


### PR DESCRIPTION
Update the segment editor URL in the config page to point to the intro-skipper/segment-editor repository. This fixes [issue 14](https://github.com/endrl/segment-editor/issues/14) in the old segment-editor repo where new users were accidentally using the outdated editor